### PR TITLE
Fix hyperlinks

### DIFF
--- a/csvs/contact_info.csv
+++ b/csvs/contact_info.csv
@@ -1,6 +1,6 @@
-,Icon used from font-awesome 4 to label this contact section,The actual value written for the contact entry
-loc,icon,contact
-email,envelope,nick.strayer@gmail.com
-twitter,twitter,NicholasStrayer
-github,github,github.com/nstrayer
-website,link,nickstrayer.me
+,Icon used from font-awesome 4 to label this contact section,The actual value written for the contact entry,
+loc,icon,contact,link
+email,envelope,nick.strayer@gmail.com,mailto:nick.strayer@gmail.com
+twitter,twitter,NicholasStrayer,https://twitter.com/NicholasStrayer
+github,github,github.com/nstrayer,https://github.com/nstrayer
+website,link,nickstrayer.me,http://nickstrayer.me/

--- a/index.Rmd
+++ b/index.Rmd
@@ -94,7 +94,7 @@ Contact {#contact}
 
 ```{r}
 contact_info %>% 
-  glue_data("- <i class='fa fa-{icon}'></i> {contact}")
+  glue_data("- <i class='fa fa-{icon}'></i> [{contact}]({link})")
 ```
 
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -24,7 +24,7 @@ library(tidyverse)
 
 # Is data stored in google sheets? If no data will be gather from the csvs/
 # folder in project
-using_googlesheets <- TRUE
+using_googlesheets <- FALSE
 
 # Just the copied URL from the sheet
 positions_sheet_loc <- "https://docs.google.com/spreadsheets/d/14MQICF2F8-vf8CKPF1m4lyGKO6_thG-4aSwat1e2TWc"


### PR DESCRIPTION
Hi Nick,

Thanks so much for sharing your CV template! It's so well-organized and beautiful. I really love the spreadsheet approach. I noticed one small thing -- your social media icons (aside from email) don't have clickable links. 

<img width="231" alt="non-clickable" src="https://user-images.githubusercontent.com/32279312/75615593-9832a080-5afa-11ea-8fbf-7febac36b904.png">

This seems to be due to the fact that the hyperlinks added to the cells in `contact_info` in `strayer_cv_data` are lost when importing the data into R. I created a workaround by adding a separate column for hyperlinks within `csvs/contact_info.csv` and adding markdown hyperlink functionality to `index.Rmd`. This creates clickable links (if desired!)

<img width="215" alt="clickable" src="https://user-images.githubusercontent.com/32279312/75615598-9d8feb00-5afa-11ea-9d9a-cb8a903b8318.png">

Of course, in order for this to work with the googlesheets workflow you'll have to add the "link" column (see example below). 

<img width="865" alt="googlesheet_link_column" src="https://user-images.githubusercontent.com/32279312/75615506-581eee00-5af9-11ea-8638-d848e4828bfa.png">

Not sure if you even wanted your contact info to be clickable, but if you do I hope this is useful! Thanks again so much for sharing your code. My CV is in dire need of beautification and your resources are incredibly helpful! 

Best,
Brendan