### PR TITLE
better call source(..., local=TRUE)

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -53,10 +53,10 @@ links <- c()
 # text output and the other loads up our data from either googlesheets or csvs
 
 # Functions for building sections from CSV data
-source('parsing_functions.R') 
+source('parsing_functions.R', local = TRUE) 
 
 # Load data for CV/Resume
-source('gather_data.R')
+source('gather_data.R', local = TRUE)
 ```
 
 


### PR DESCRIPTION
From the documentation of `?source`, we know that the `local` argument:

>  FALSE (the default) corresponds to the user's workspace (the global environment) and TRUE to the environment from which source is called.

It means if we call `source()` without specifying `local=TRUE`, the global environment will be polluted. 

It has no differences if you just use RStudio IDE and click the knit button, as RStudio will evaluate the knit in a separate R session. 

However, if you want to knit the Rmd file via R commands, `local=TRUE` is preferred, in my opinion.

Anyway, it's a very very trivial issue, please feel free to close it if you don't think it's necessary.

Thanks.